### PR TITLE
Add option for preventing the renaming of locked items + Update to 1.16.5

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.newt</groupId>
     <artifactId>EnchantmentLock</artifactId>
-    <version>MC-1.16.1</version>
+    <version>MC-1.16.5-will278</version>
     <description>Prevent enchantments on items from being changed by players.</description>
 
     <repositories>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.2-R0.1-SNAPSHOT</version>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.newt</groupId>
     <artifactId>EnchantmentLock</artifactId>
-    <version>MC-1.16.5-will278</version>
+    <version>MC-1.16.5</version>
     <description>Prevent enchantments on items from being changed by players.</description>
 
     <repositories>

--- a/src/main/java/me/newt/enchantmentlock/EnchantmentLock.java
+++ b/src/main/java/me/newt/enchantmentlock/EnchantmentLock.java
@@ -22,6 +22,7 @@ public class EnchantmentLock extends JavaPlugin {
     public boolean block_anvil_repair;
     public boolean block_grindstone;
     public boolean block_smithing;
+    public boolean block_name_change;
     public ItemManager itemManager;
     public MessageManager messageManager;
 
@@ -40,6 +41,7 @@ public class EnchantmentLock extends JavaPlugin {
 
         block_enchanting_table = configuration.getBoolean("block_enchanting_table");
         block_anvil_enchanting = configuration.getBoolean("block_anvil_enchanting");
+        block_name_change = configuration.getBoolean("block_name_change");
         block_anvil_repair = configuration.getBoolean("block_anvil_repair");
         block_grindstone = configuration.getBoolean("block_grindstone");
         block_smithing = configuration.getBoolean("block_smithing");

--- a/src/main/java/me/newt/enchantmentlock/MessageManager.java
+++ b/src/main/java/me/newt/enchantmentlock/MessageManager.java
@@ -12,6 +12,7 @@ public class MessageManager {
     public String cannot_disenchant;
     public String cannot_repair;
     public String cannot_smith;
+    public String cannot_rename;
 
     /**
      * Constructor for the MessageManager.
@@ -22,15 +23,18 @@ public class MessageManager {
         this.cannot_disenchant = enchantmentLock.getConfig().getString("cannot_disenchant");
         this.cannot_repair = enchantmentLock.getConfig().getString("cannot_repair");
         this.cannot_smith = enchantmentLock.getConfig().getString("cannot_smith");
+        this.cannot_rename = enchantmentLock.getConfig().getString("cannot_rename");
 
         assert cannot_enchant != null : "Invalid configuration. Could not load message.";
         assert cannot_disenchant != null : "Invalid configuration. Could not load message.";
         assert cannot_repair != null : "Invalid configuration. Could not load message.";
         assert cannot_smith != null : "Invalid configuration. Could not load message.";
+        assert cannot_rename != null : "Invalid configuration. Could not load message.";
 
         cannot_enchant = ChatColor.translateAlternateColorCodes('&', cannot_enchant);
         cannot_disenchant = ChatColor.translateAlternateColorCodes('&', cannot_disenchant);
         cannot_repair = ChatColor.translateAlternateColorCodes('&', cannot_repair);
         cannot_smith = ChatColor.translateAlternateColorCodes('&', cannot_smith);
+        cannot_rename = ChatColor.translateAlternateColorCodes('&', cannot_rename);
     }
 }

--- a/src/main/java/me/newt/enchantmentlock/feature/BlockAnvil.java
+++ b/src/main/java/me/newt/enchantmentlock/feature/BlockAnvil.java
@@ -11,9 +11,11 @@ import org.bukkit.inventory.AnvilInventory;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 /**
  * Updated to support minecraft 1.16.1.
+ *
  * @author Newt
  */
 public class BlockAnvil implements Listener {
@@ -22,6 +24,7 @@ public class BlockAnvil implements Listener {
 
     /**
      * Constructor for the BlockEnchantingTable Listener.
+     *
      * @param enchantmentLock Instance of the main class.
      */
     public BlockAnvil(EnchantmentLock enchantmentLock) {
@@ -29,7 +32,46 @@ public class BlockAnvil implements Listener {
     }
 
     /**
+     * Returns whether or not the item has been renamed
+     * @param item ItemStack original item put in anvil
+     * @param result ItemStack result from using the anvil
+     * @return Whether or not the item has been renamed
+     */
+    private boolean isChangeInName(ItemStack item, ItemStack result) {
+        String itemName;
+        String resultName;
+
+        if (item.hasItemMeta()) {
+            ItemMeta itemMeta = item.getItemMeta();
+            if (itemMeta.hasDisplayName()) {
+                itemName = item.getItemMeta().getDisplayName();
+            } else {
+                itemName = item.getType().name();
+            }
+        } else {
+            itemName = item.getType().name();
+        }
+
+        if (result.hasItemMeta()) {
+            ItemMeta resultMeta = result.getItemMeta();
+            if (resultMeta.hasDisplayName()) {
+                resultName = item.getItemMeta().getDisplayName();
+            } else {
+                resultName = item.getType().name();
+            }
+        } else {
+            resultName = item.getType().name();
+        }
+
+        if (!itemName.equals(resultName)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Anvil event.
+     *
      * @param event The respective event listened to.
      */
     @EventHandler
@@ -53,6 +95,7 @@ public class BlockAnvil implements Listener {
         boolean involvesLockedItem = false;
         boolean isRepair = false;
         boolean isChangeInEnchantments = false;
+        boolean isChangeInName = false;
 
         if (item == null) return;
         if (result == null) return;
@@ -68,6 +111,8 @@ public class BlockAnvil implements Listener {
                 isRepair = false;
                 isChangeInEnchantments = true;
             }
+
+            isChangeInName = isChangeInName(item, result);
         }
 
         if (!involvesLockedItem) return;
@@ -78,9 +123,17 @@ public class BlockAnvil implements Listener {
             return;
         }
 
+        if (enchantmentLock.block_name_change && isChangeInName) {
+            event.setCancelled(true);
+            player.sendMessage(enchantmentLock.messageManager.cannot_rename);
+            return;
+        }
+
         if (enchantmentLock.block_anvil_repair && isRepair) {
             event.setCancelled(true);
             player.sendMessage(enchantmentLock.messageManager.cannot_repair);
         }
+
+
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,6 +19,7 @@ cannot_enchant: "&cThis item cannot be enchanted."
 cannot_disenchant: "&cThe enchantments on this item cannot be removed."
 cannot_repair: "&cThis item cannot be repaired."
 cannot_smith: "&cThis item cannot be upgraded to netherite."
+cannot_rename: "&cThis item cannot be renamed."
 
 # Toggle parts of the plugin. By default, all ways to (dis)enchant an item are prevented.
 # Prevent players from enchanting locked items with an Enchanting Table.
@@ -29,6 +30,9 @@ block_anvil_enchanting: true
 
 # Prevent players from repairing & combining locked items with an Anvil.
 block_anvil_repair: true
+
+# Prevent players from changing the name of locked items with an Anvil.
+block_name_change: true
 
 # Prevent players from disenchanting locked items with a Grindstone.
 block_grindstone: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,9 @@ name: ${project.name}
 version: ${project.version}
 description: ${project.description}
 
-authors: [Newt]
+authors:
+  - Newt
+  - William278
 main: me.newt.enchantmentlock.EnchantmentLock
 website: https://github.com/JustDJplease/EnchantmentLock
 


### PR DESCRIPTION
Not sure if you're still maintaining this, but someone requested a patch of this that prevents item renaming, which is what this does.
I added a config option to enable/disable this (true by default) and a new error message that appears if this is on. Also updated the version to use the 1.16.5 Spigot API instead of 1.16.1
Thanks :)